### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/io.github.alainm23.planify.json
+++ b/io.github.alainm23.planify.json
@@ -16,12 +16,10 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
+        "/share/gir-1.0",
+        "/share/vala",
         "*.la",
         "*.a"
     ],


### PR DESCRIPTION
- Drop ineffective cleanup commands
- Improve cleanup commands to reduce the Flatpak size

The installed size reduced from 30 MB to 15 MB.